### PR TITLE
comment metadata block in kitty config

### DIFF
--- a/kitty/edelweiss.conf
+++ b/kitty/edelweiss.conf
@@ -3,11 +3,11 @@
 #: Theme files should start with a metadata block consisting of
 #: lines beginning with ##. All metadata fields are optional.
 
-name: edelweiss
-author: Timo Furrer
-license: MIT
-upstream: https://tuxtimo.me
-blurb: Light colored theme, just that. edelweiss.
+#: name: edelweiss
+#: author: Timo Furrer
+#: license: MIT
+#: upstream: https://tuxtimo.me
+#: blurb: Light colored theme, just that. edelweiss.
 
 #: All the settings below are colors, which you can choose to modify, or use the
 #: defaults. You can also add non-color based settings if needed but note that

--- a/kitty/edelweiss.conf
+++ b/kitty/edelweiss.conf
@@ -6,7 +6,7 @@
 #: name: edelweiss
 #: author: Timo Furrer
 #: license: MIT
-#: upstream: https://tuxtimo.me
+#: upstream: https://github.com/timofurrer/edelweiss
 #: blurb: Light colored theme, just that. edelweiss.
 
 #: All the settings below are colors, which you can choose to modify, or use the


### PR DESCRIPTION
Not a huge fan of the startup warnings:
[083 16:38:05.574082] Ignoring invalid config line: 'name: edelweiss' 
[083 16:38:05.574126] Ignoring invalid config line: 'author: Timo Furrer' 
[083 16:38:05.574138] Ignoring invalid config line: 'license: MIT' 
[083 16:38:05.574151] Ignoring invalid config line: 'upstream: https://tuxtimo.me' 
[083 16:38:05.574160] Ignoring invalid config line: 'blurb: Light colored theme, just that. edelweiss.'